### PR TITLE
Fix operator< in negotiation

### DIFF
--- a/include/telnetpp/negotiation.hpp
+++ b/include/telnetpp/negotiation.hpp
@@ -59,8 +59,7 @@ constexpr bool operator==(negotiation const &lhs, negotiation const &rhs)
 constexpr bool operator<(negotiation const &lhs, negotiation const &rhs)
 {
     return lhs.request() < rhs.request()
-         ? true
-         : lhs.option() < rhs.option();
+        || (!(rhs.request() < lhs.request()) && lhs.option() < rhs.option());
 }
 
 //* =========================================================================


### PR DESCRIPTION
Usually, I would use std::pair to do it, but one version of g++
complained about using that in a constexpr.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/kazdragon/telnetpp/78)
<!-- Reviewable:end -->
