### PR TITLE
Removed extraneous reference in stream_match visitor

### DIFF
--- a/test/session_test.cpp
+++ b/test/session_test.cpp
@@ -18,7 +18,7 @@ struct stream_match : boost::static_visitor<>
     
     void operator()(boost::any const &any) const
     {
-        boost::get<boost::any&>(expected_);
+        boost::get<boost::any>(expected_);
     }
     
     void operator()(telnetpp::u8stream const &stream) const


### PR DESCRIPTION
This triggers a static assert with certain versions of Boost.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/telnetpp/93)
<!-- Reviewable:end -->