### PR TITLE
ZLib decompressor now throws exception when receiving a bad stream.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ set (telnetpp_public_src
     src/negotiation.cpp
     src/options/mccp/client.cpp
     src/options/mccp/codec.cpp
+    src/options/mccp/decompressor.cpp
     src/options/mccp/server.cpp
     src/options/mccp/zlib/compressor.cpp
     src/options/mccp/zlib/decompressor.cpp

--- a/include/telnetpp/options/mccp/decompressor.hpp
+++ b/include/telnetpp/options/mccp/decompressor.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "telnetpp/core.hpp"
+#include <boost/exception/all.hpp>
 #include <tuple>
+#include <stdexcept>
 
 namespace telnetpp { namespace options { namespace mccp {
 
@@ -20,6 +22,9 @@ public :
     /// \brief Decompress the given byte, and return a tuple of the
     /// decompressed data and a boolean that is set to true if this was the
     /// end of the decompression stream.
+    /// \throws telnetpp::options::mccp::corrupted_stream_error if data was
+    /// passed that it could not decompress.  I.e. the stream has been
+    /// corrupted or otherwise constructed in an invalid manner.
     //* =====================================================================
     virtual std::tuple<telnetpp::u8stream, bool> decompress(
         telnetpp::u8 byte) = 0;
@@ -29,6 +34,19 @@ public :
     /// to decompress continue as if the stream were created fresh.
     //* =====================================================================
     virtual void end_decompression() = 0;
+};
+
+//* =========================================================================
+/// \brief An exception that is thrown in the case that a stream of data
+/// cannot be decompressed.
+//* =========================================================================
+class corrupted_stream_error
+  : virtual std::domain_error,
+    virtual boost::exception
+{
+public :
+    corrupted_stream_error(std::string const &what_arg);
+    corrupted_stream_error(char const *what_arg);
 };
 
 }}}

--- a/src/options/mccp/decompressor.cpp
+++ b/src/options/mccp/decompressor.cpp
@@ -1,0 +1,21 @@
+#include "telnetpp/options/mccp/decompressor.hpp"
+
+namespace telnetpp { namespace options { namespace mccp {
+
+// ==========================================================================
+// CORRUPTED_STREAM_ERROR::CONSTRUCTOR
+// ==========================================================================
+corrupted_stream_error::corrupted_stream_error(std::string const &what_arg)
+  : domain_error(what_arg)
+{
+}
+  
+// ==========================================================================
+// CORRUPTED_STREAM_ERROR::CONSTRUCTOR
+// ==========================================================================
+corrupted_stream_error::corrupted_stream_error(char const *what_arg)
+  : domain_error(what_arg)
+{
+}
+  
+}}}

--- a/src/options/mccp/zlib/decompressor.cpp
+++ b/src/options/mccp/zlib/decompressor.cpp
@@ -48,8 +48,16 @@ public :
         stream_.next_out  = input_buffer;
 
         auto response = inflate(&stream_, Z_SYNC_FLUSH);
+        
+        if (response == Z_DATA_ERROR)
+        {
+            throw corrupted_stream_error(
+                "Inflation of byte in ZLib stream yielded Z_DATA_ERROR");
+        }
+        
         assert(response == Z_OK || response == Z_STREAM_END);
 
+        // Error in stream yields Z_DATA_ERROR
         is_end_of_stream = response == Z_STREAM_END;
 
         decompressed_stream.insert(


### PR DESCRIPTION
Closes #125

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/telnetpp/127)
<!-- Reviewable:end -->
