### PR TITLE
Unified client_option and server_option interfaces.

### DIFF
--- a/include/telnetpp/client_option.hpp
+++ b/include/telnetpp/client_option.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "telnetpp/core.hpp"
 #include "telnetpp/element.hpp"
 #include <boost/signals2.hpp>
 #include <vector>
@@ -15,11 +14,19 @@ namespace telnetpp {
 /// \par
 /// Note that the usage of client in this context may disagree with a
 /// particular option's RFC specification.  The determination of what is a
-/// server and what is a client is not rigorously applies throughout the
+/// client and what is a client is not rigorously applies throughout the
 /// RFCs, so consider this merely an implementation detail of this library.
 //* =========================================================================
 class TELNETPP_EXPORT client_option {
 public :
+    enum class state
+    {
+        inactive,
+        activating,
+        active,
+        deactivating,
+    };
+
     //* =====================================================================
     /// \brief Constructor
     //* =====================================================================
@@ -62,9 +69,10 @@ public :
         u8stream const &content);
 
     boost::signals2::signal<
-        std::vector<token> (),
+        std::vector<telnetpp::token> (state new_state),
         token_combiner
     > on_state_changed;
+
 
 private :
     //* =====================================================================
@@ -73,14 +81,6 @@ private :
     //* =====================================================================
     virtual std::vector<telnetpp::token> handle_subnegotiation(
         u8stream const &content);
-
-    enum class state
-    {
-        inactive,
-        activating,
-        active,
-        deactivating,
-    };
 
     state state_       = state::inactive;
     bool  activatable_ = false;

--- a/include/telnetpp/client_option.hpp
+++ b/include/telnetpp/client_option.hpp
@@ -14,7 +14,7 @@ namespace telnetpp {
 /// \par
 /// Note that the usage of client in this context may disagree with a
 /// particular option's RFC specification.  The determination of what is a
-/// client and what is a client is not rigorously applies throughout the
+/// client and what is a server is not rigorously applies throughout the
 /// RFCs, so consider this merely an implementation detail of this library.
 //* =========================================================================
 class TELNETPP_EXPORT client_option {

--- a/src/client_option.cpp
+++ b/src/client_option.cpp
@@ -157,9 +157,9 @@ std::vector<telnetpp::token> client_option::negotiate(telnetpp::u8 request)
         case state::deactivating :
             if (request == telnetpp::will)
             {
-                // NOTE: This is technically unspecified.  No client would send
-                // a DO when we're already active, and they're not allowed to
-                // send a DO after receiving a WONT.  But to be nice, we'll
+                // NOTE: This is technically unspecified.  No server would send
+                // a WILL when we're already active, and they're not allowed to
+                // send a WILL after receiving a DONT.  But to be nice, we'll
                 // re-activate.
                 state_ = state::active;
                 return on_state_changed(state_);

--- a/src/client_option.cpp
+++ b/src/client_option.cpp
@@ -35,15 +35,21 @@ std::vector<telnetpp::token> client_option::activate()
     if (state_ == state::inactive)
     {
         state_ = state::activating;
-        return { telnetpp::element {
-            telnetpp::negotiation(telnetpp::do_, option_) }
-        };
+        auto response = on_state_changed(state_);
+
+        response.insert(
+            response.begin(),
+            { telnetpp::element(
+                telnetpp::negotiation(telnetpp::do_, option_)
+            )});
+
+        return response;
     }
     else
     {
         if (state_ == state::active)
         {
-            return on_state_changed();
+            return on_state_changed(state_);
         }
         else
         {
@@ -59,16 +65,21 @@ std::vector<telnetpp::token> client_option::deactivate()
 {
     if (state_ == state::inactive)
     {
-        return on_state_changed();
+        return on_state_changed(state_);
     }
 
     if (state_ == state::active)
     {
         state_ = state::deactivating;
+        auto response = on_state_changed(state_);
 
-        return {
-            telnetpp::element(telnetpp::negotiation(telnetpp::dont, option_))
-        };
+        response.insert(
+            response.begin(),
+            { telnetpp::element(
+                telnetpp::negotiation(telnetpp::dont, option_)
+            )});
+
+        return response;
     }
     else
     {
@@ -95,53 +106,50 @@ std::vector<telnetpp::token> client_option::negotiate(telnetpp::u8 request)
             if (request == telnetpp::will && activatable_)
             {
                 state_ = state::active;
-                auto response = on_state_changed();
+                auto response = on_state_changed(state_);
                 response.insert(
                     response.begin(),
-                    { telnetpp::element {
-                        telnetpp::negotiation(telnetpp::do_, option_) }
-                    });
+                    { telnetpp::element(
+                        telnetpp::negotiation(telnetpp::do_, option_)
+                    )});
 
                 return response;
             }
             else
             {
-                return { telnetpp::element {
-                    telnetpp::negotiation(telnetpp::dont, option_) }
-                };
+                return { telnetpp::element(
+                    telnetpp::negotiation(telnetpp::dont, option_)
+                )};
             }
 
         case state::activating :
             if (request == telnetpp::will)
             {
                 state_ = state::active;
-                return on_state_changed();
+                return on_state_changed(state_);
             }
-            else if (request == telnetpp::wont)
+            else
             {
                 state_ = state::inactive;
-                return on_state_changed();
+                return on_state_changed(state_);
             }
-
-            return {};
 
         case state::active :
             if (request == telnetpp::will)
             {
-                return { telnetpp::element {
-                    telnetpp::negotiation(telnetpp::do_, option_) }
-                };
+                return { telnetpp::element(
+                    telnetpp::negotiation(telnetpp::do_, option_)
+                )};
             }
-            else if (request == telnetpp::wont)
+            else
             {
                 state_ = state::inactive;
-
-                auto response = on_state_changed();
+                auto response = on_state_changed(state_);
                 response.insert(
                     response.begin(),
-                    telnetpp::element {
+                    { telnetpp::element(
                         telnetpp::negotiation(telnetpp::dont, option_)
-                    });
+                    )});
 
                 return response;
             }
@@ -150,20 +158,20 @@ std::vector<telnetpp::token> client_option::negotiate(telnetpp::u8 request)
             if (request == telnetpp::will)
             {
                 // NOTE: This is technically unspecified.  No client would send
-                // a WILL when we're already active, and they're not allowed to
-                // send a WILL after receiving a DONT.  But to be nice, we'll
+                // a DO when we're already active, and they're not allowed to
+                // send a DO after receiving a WONT.  But to be nice, we'll
                 // re-activate.
                 state_ = state::active;
-                return on_state_changed();
+                return on_state_changed(state_);
             }
             else if (request == telnetpp::wont)
             {
                 state_ = state::inactive;
-                return on_state_changed();
+                return on_state_changed(state_);
             }
-
-            return {};
     }
+
+    return {};
 }
 
 // ==========================================================================
@@ -186,7 +194,7 @@ std::vector<telnetpp::token> client_option::subnegotiate(
 // HANDLE_SUBNEGOTIATION
 // ==========================================================================
 std::vector<telnetpp::token> client_option::handle_subnegotiation(
-    u8stream const&)
+    u8stream const &)
 {
     // By default, do nothing.
     return {};

--- a/src/options/mccp/client.cpp
+++ b/src/options/mccp/client.cpp
@@ -11,11 +11,17 @@ client::client()
   : client_option(detail::option)
 {
     on_state_changed.connect(
-        []
+        [](client_option::state state)
+            -> std::vector<telnetpp::token>
         {
-           return std::vector<telnetpp::token>{
-               boost::any(end_decompression{})
-           };
+            if (state == client_option::state::inactive)
+            {
+                return { boost::any(end_decompression{}) };
+            }
+            else
+            {
+                return {};
+            }
         });
 }
 

--- a/test/pass_through_test.cpp
+++ b/test/pass_through_test.cpp
@@ -15,7 +15,7 @@ public :
       : telnetpp::client_option(pass_through_option_id)
     {
         on_state_changed.connect(
-            []() -> std::vector<telnetpp::token>
+            [](telnetpp::client_option::state) -> std::vector<telnetpp::token>
             {
                 return { boost::any(test_string) };
             });

--- a/test/routing_visitor_test.cpp
+++ b/test/routing_visitor_test.cpp
@@ -87,7 +87,8 @@ TEST(routing_visitor_test, negotiation_routes_to_negotiation_router)
 
     bool state_changed = false;
     client.on_state_changed.connect(
-        [&state_changed]() -> std::vector<telnetpp::token>
+        [&state_changed](telnetpp::client_option::state state)
+            -> std::vector<telnetpp::token>
         {
             state_changed = true;
             return {};


### PR DESCRIPTION
MCCP server requires knowing about the deactivatING state,
so I went with the more complex server_option interface.

Closes #119

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/telnetpp/129)
<!-- Reviewable:end -->
