### PR TITLE
Fix compiler error when using initializer list of variables

### DIFF
--- a/src/options/msdp/variable.cpp
+++ b/src/options/msdp/variable.cpp
@@ -71,7 +71,7 @@ variable::variable(
     std::string const &name,
     std::initializer_list<variable> const &il)
   : name(name),
-    value(il)
+    value(std::vector<variable>{il})
 {
 }
 


### PR DESCRIPTION
Doesn't work as-is with Clang 3.8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/telnetpp/165)
<!-- Reviewable:end -->
