### PR TITLE
Removed clang and gcov-5 from Travis coverage build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,8 @@ matrix:
         apt:
           sources: *sources
           packages:
-            - clang
             - gcc-5
             - g++-5
-            - gcov-5
             - libgtest-dev
             - libboost1.55-all-dev
 
@@ -129,7 +127,7 @@ before_script:
 
 script:
   - make -j2
-  - if [ "$COVERAGE" == "ON" ]; then 
+  - if [ "$COVERAGE" == "ON" ]; then
         $LCOV --gcov-tool=gcov-5 --base-directory . --directory . --zerocounters -q;
     fi
   - make test


### PR DESCRIPTION
clang was never necessary and gcov-5 is now pre-installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/telnetpp/170)
<!-- Reviewable:end -->
