### PR TITLE
Fix for compilation on Clang 3.9

### DIFF
--- a/src/options/msdp/detail/decoder.cpp
+++ b/src/options/msdp/detail/decoder.cpp
@@ -2,6 +2,7 @@
 #include "telnetpp/options/msdp/detail/protocol.hpp"
 #include <algorithm>
 #include <cassert>
+#include <functional>
 
 namespace telnetpp { namespace options { namespace msdp { namespace detail {
 


### PR DESCRIPTION
std::ref is present in &lt;functional>, and this is not currently explicitly included.
Other versions just get lucky.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/telnetpp/192)
<!-- Reviewable:end -->
