### PR TITLE
Include <ostream> in variable.cpp

### DIFF
--- a/include/telnetpp/options/msdp/variable.hpp
+++ b/include/telnetpp/options/msdp/variable.hpp
@@ -5,7 +5,6 @@
 #include <boost/variant.hpp>
 #include <iosfwd>
 #include <string>
-#include <ostream>
 
 namespace telnetpp { namespace options { namespace msdp {
 

--- a/include/telnetpp/options/msdp/variable.hpp
+++ b/include/telnetpp/options/msdp/variable.hpp
@@ -5,6 +5,7 @@
 #include <boost/variant.hpp>
 #include <iosfwd>
 #include <string>
+#include <ostream>
 
 namespace telnetpp { namespace options { namespace msdp {
 

--- a/src/options/msdp/variable.cpp
+++ b/src/options/msdp/variable.cpp
@@ -1,5 +1,6 @@
 #include "telnetpp/options/msdp/variable.hpp"
 #include "telnetpp/detail/lambda_visitor.hpp"
+#include <ostream>
 
 namespace telnetpp { namespace options { namespace msdp {
 


### PR DESCRIPTION
In a future version of MSVC, \<string> doesn't transitively include\<ostream>.
This port will compile failed with variable.cpp(109): error C2679: binary '<<': no operator found which takes a right-hand operand of type 'const char *' (or there is no acceptable conversion), so I add include\<ostream> into the header file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/telnetpp/215)
<!-- Reviewable:end -->
