### PR TITLE
Removed withTests conan option in favour of always building with tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ before_script:
   - cd build
   - conan remote add nonstd-lite https://api.bintray.com/conan/martinmoene/nonstd-lite || true
   - conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan || true
-  - conan install .. -s compiler.libcxx=libstdc++11 -s cppstd=14 -s build_type=$CONFIG -o telnetpp:shared=$SHARED -o telnetpp:sanitize=$SANITIZE -o telnetpp:withTests=True -o telnetpp:withZlib=True -o telnetpp:coverage=$COVERAGE --build=missing
+  - conan install .. -s compiler.libcxx=libstdc++11 -s cppstd=14 -s build_type=$CONFIG -o telnetpp:shared=$SHARED -o telnetpp:sanitize=$SANITIZE -o telnetpp:withZlib=True -o telnetpp:coverage=$COVERAGE --build=missing
 
 script:
   - conan build ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,12 +12,10 @@ if (POLICY CMP0063)
     cmake_policy(SET CMP0063 OLD) # Do not allow hidden visibility for static libs
 endif()
 
-option(TELNETPP_WITH_TESTS "Build with tests included" False)
 option(TELNETPP_WITH_ZLIB "Build using ZLib" False)
 option(TELNETPP_COVERAGE  "Build with code coverage options")
 option(TELNETPP_SANITIZE "Build using sanitizers" "")
 message("Building Telnet++ with config: ${CMAKE_BUILD_TYPE}")
-message("Building Telnet++ with tests: ${TELNETPP_WITH_TESTS}")
 message("Building Telnet++ with zlib: ${TELNETPP_WITH_ZLIB}")
 message("Building Telnet++ with code coverage: ${TELNETPP_COVERAGE}")
 message("Building Telnet++ with sanitizers: ${TELNETPP_SANITIZE}")
@@ -239,78 +237,76 @@ install(
         lib/telnetpp-${TELNETPP_VERSION}
 )
 
-if (TELNETPP_WITH_TESTS)
-    enable_testing()
+enable_testing()
 
+set (telnetpp_tester_external_tests
+    test/client_option_test.cpp
+    test/command_router_test.cpp
+    test/echo_client_test.cpp
+    test/echo_server_test.cpp
+    test/generator_test.cpp
+    test/mccp_client_test.cpp
+    test/mccp_server_test.cpp
+    test/msdp_client_test.cpp
+    test/msdp_server_test.cpp
+    test/naws_client_test.cpp
+    test/naws_server_test.cpp
+    test/new_environ_client_test.cpp
+    test/new_environ_server_test.cpp
+    test/negotiation_router_test.cpp
+    test/parser_test.cpp
+    test/q_method_test.cpp
+    test/server_option_test.cpp
+    test/session_test.cpp
+    test/subnegotiation_router_test.cpp
+    test/suppress_ga_client_test.cpp
+    test/suppress_ga_server_test.cpp
+    test/terminal_type_client_test.cpp
+)
+
+# The tests for the zlib compressors for MCCP should only be compiled into
+# the executable if zlib is available.
+if (TELNETPP_WITH_ZLIB)
     set (telnetpp_tester_external_tests
-        test/client_option_test.cpp
-        test/command_router_test.cpp
-        test/echo_client_test.cpp
-        test/echo_server_test.cpp
-        test/generator_test.cpp
-        test/mccp_client_test.cpp
-        test/mccp_server_test.cpp
-        test/msdp_client_test.cpp
-        test/msdp_server_test.cpp
-        test/naws_client_test.cpp
-        test/naws_server_test.cpp
-        test/new_environ_client_test.cpp
-        test/new_environ_server_test.cpp
-        test/negotiation_router_test.cpp
-        test/parser_test.cpp
-        test/q_method_test.cpp
-        test/server_option_test.cpp
-        test/session_test.cpp
-        test/subnegotiation_router_test.cpp
-        test/suppress_ga_client_test.cpp
-        test/suppress_ga_server_test.cpp
-        test/terminal_type_client_test.cpp
+        ${telnetpp_tester_external_tests}
+        test/mccp_zlib_compressor_test.cpp
+        test/mccp_zlib_decompressor_test.cpp
     )
+endif()
 
-    # The tests for the zlib compressors for MCCP should only be compiled into
-    # the executable if zlib is available.
-    if (TELNETPP_WITH_ZLIB)
-        set (telnetpp_tester_external_tests
-            ${telnetpp_tester_external_tests}
-            test/mccp_zlib_compressor_test.cpp
-            test/mccp_zlib_decompressor_test.cpp
-        )
-    endif()
-
-    # If we are building shared libraries, then we wont be able to test any of
-    # the modules in the detail directory since they're not visible (this is ok,
-    # since all those are tested indirectly via other parts of the API anyway.)
-    # For a normal archive, all symbols are visible, so they can be tested directly.
-    if (BUILD_SHARED_LIBS)
-        set(telnetpp_tester_tests
-            ${telnetpp_tester_external_tests}
-        )
-    else()
-        set(telnetpp_tester_tests
-            ${telnetpp_tester_internal_tests}
-            ${telnetpp_tester_external_tests}
-        )
-    endif()
-
-    add_executable(telnetpp_tester
-        ${telnetpp_tester_tests}
+# If we are building shared libraries, then we wont be able to test any of
+# the modules in the detail directory since they're not visible (this is ok,
+# since all those are tested indirectly via other parts of the API anyway.)
+# For a normal archive, all symbols are visible, so they can be tested directly.
+if (BUILD_SHARED_LIBS)
+    set(telnetpp_tester_tests
+        ${telnetpp_tester_external_tests}
     )
+else()
+    set(telnetpp_tester_tests
+        ${telnetpp_tester_internal_tests}
+        ${telnetpp_tester_external_tests}
+    )
+endif()
 
+add_executable(telnetpp_tester
+    ${telnetpp_tester_tests}
+)
+
+target_link_libraries(telnetpp_tester
+    PRIVATE
+        telnetpp
+        CONAN_PKG::gtest
+)
+
+if (TELNETPP_WITH_ZLIB)
     target_link_libraries(telnetpp_tester
         PRIVATE
-            telnetpp
-            CONAN_PKG::gtest
+            CONAN_PKG::zlib
     )
-
-    if (TELNETPP_WITH_ZLIB)
-        target_link_libraries(telnetpp_tester
-            PRIVATE
-                CONAN_PKG::zlib
-        )
-    endif()
-
-    add_test(telnetpp_test telnetpp_tester)
 endif()
+
+add_test(telnetpp_test telnetpp_tester)
 
 # Add a rule for generating documentation
 if (DOXYGEN_FOUND)

--- a/conanfile.py
+++ b/conanfile.py
@@ -16,20 +16,17 @@ class ConanTelnetpp(ConanFile):
                 "boost_signals2/[>=1.69]@bincrafters/stable",
                 "boost_variant/[>=1.69]@bincrafters/stable",
                 "gsl-lite/[>=0.34]@nonstd-lite/stable")
-    options = {"shared": [True, False], "withTests": [True, False], "withZlib": [True, False], "coverage": [True, False], "sanitize" : ["off", "address"]}
-    default_options = {"shared": False, "withTests": False, "withZlib": True, "coverage": False, "sanitize": "off"}
+    build_requires = ("gtest/[>=1.8.1]@bincrafters/stable")
+    options = {"shared": [True, False], "withZlib": [True, False], "coverage": [True, False], "sanitize" : ["off", "address"]}
+    default_options = {"shared": False, "withZlib": True, "coverage": False, "sanitize": "off"}
 
     def requirements(self):
-        if (self.options.withTests):
-            self.requires("gtest/[>=1.8.1]@bincrafters/stable")
-
         if (self.options.withZlib):
             self.requires("zlib/[>=1.2.11]@conan/stable")
 
     def configure_cmake(self):
         cmake = CMake(self)
         cmake.definitions["BUILD_SHARED_LIBS"] = self.options.shared
-        cmake.definitions["TELNETPP_WITH_TESTS"] = self.options.withTests
         cmake.definitions["TELNETPP_WITH_ZLIB"] = self.options.withZlib
         cmake.definitions["TELNETPP_COVERAGE"] = self.options.coverage
         cmake.definitions["TELNETPP_SANITIZE"] = self.options.sanitize


### PR DESCRIPTION
gtest was added to the "build_requires" setting, meaning that it's still not
required for actual use of the library; only building.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/telnetpp/217)
<!-- Reviewable:end -->
