### PR TITLE
Renamed subnegotiationless_* to basic_*.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,8 @@ target_sources(telnetpp
         include/telnetpp/subnegotiation.hpp
         include/telnetpp/telnetpp.hpp
         include/telnetpp/version.hpp
+        include/telnetpp/options/basic_client.hpp
+        include/telnetpp/options/basic_server.hpp
         include/telnetpp/options/echo/client.hpp
         include/telnetpp/options/echo/server.hpp
         include/telnetpp/options/mccp/client.hpp
@@ -164,8 +166,6 @@ target_sources(telnetpp
         include/telnetpp/options/new_environ/client.hpp
         include/telnetpp/options/new_environ/server.hpp
         include/telnetpp/options/terminal_type/client.hpp
-        include/telnetpp/options/subnegotiationless_client.hpp
-        include/telnetpp/options/subnegotiationless_server.hpp
         include/telnetpp/options/suppress_ga/client.hpp
         include/telnetpp/options/suppress_ga/server.hpp
 

--- a/include/telnetpp/options/basic_client.hpp
+++ b/include/telnetpp/options/basic_client.hpp
@@ -10,13 +10,13 @@ namespace telnetpp { namespace options {
 ///        the option.
 //* =========================================================================
 template <option_type Option>
-class subnegotiationless_client : public telnetpp::client_option
+class basic_client : public telnetpp::client_option
 {
 public:
     //* =====================================================================
     /// \brief Constructor
     //* =====================================================================
-    constexpr subnegotiationless_client() noexcept
+    constexpr basic_client() noexcept
       : client_option(Option)
     {
     }

--- a/include/telnetpp/options/basic_server.hpp
+++ b/include/telnetpp/options/basic_server.hpp
@@ -10,13 +10,13 @@ namespace telnetpp { namespace options {
 ///        the option.
 //* =========================================================================
 template <option_type Option>
-class subnegotiationless_server : public telnetpp::server_option
+class basic_server : public telnetpp::server_option
 {
 public:
     //* =====================================================================
     /// \brief Constructor
     //* =====================================================================
-    constexpr subnegotiationless_server() noexcept
+    constexpr basic_server() noexcept
       : server_option(Option)
     {
     }

--- a/include/telnetpp/options/echo/client.hpp
+++ b/include/telnetpp/options/echo/client.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "telnetpp/options/subnegotiationless_client.hpp"
+#include "telnetpp/options/basic_client.hpp"
 #include "telnetpp/options/echo/detail/protocol.hpp"
 
 namespace telnetpp { namespace options { namespace echo {
@@ -11,8 +11,10 @@ namespace telnetpp { namespace options { namespace echo {
 /// \brief An implementation of the client side of Telnet ECHO option
 /// \see https://tools.ietf.org/html/rfc857
 //* =========================================================================
-using client = telnetpp::options::subnegotiationless_client<
+class client : public telnetpp::options::basic_client<
     telnetpp::options::echo::detail::option
->;
+>
+{
+};
 
 }}}

--- a/include/telnetpp/options/echo/server.hpp
+++ b/include/telnetpp/options/echo/server.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "telnetpp/options/subnegotiationless_server.hpp"
+#include "telnetpp/options/basic_server.hpp"
 #include "telnetpp/options/echo/detail/protocol.hpp"
 
 namespace telnetpp { namespace options { namespace echo {
@@ -11,8 +11,10 @@ namespace telnetpp { namespace options { namespace echo {
 /// \brief An implementation of the server side of Telnet ECHO option
 /// \see https://tools.ietf.org/html/rfc857
 //* =========================================================================
-using server = telnetpp::options::subnegotiationless_server<
+class server : public telnetpp::options::basic_server<
     telnetpp::options::echo::detail::option
->;
+>
+{
+};
 
 }}}

--- a/include/telnetpp/options/suppress_ga/client.hpp
+++ b/include/telnetpp/options/suppress_ga/client.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "telnetpp/options/subnegotiationless_client.hpp"
+#include "telnetpp/options/basic_client.hpp"
 #include "telnetpp/options/suppress_ga/detail/protocol.hpp"
 
 namespace telnetpp { namespace options { namespace suppress_ga {
@@ -12,8 +12,10 @@ namespace telnetpp { namespace options { namespace suppress_ga {
 /// Ahead option.
 /// \see https://tools.ietf.org/html/rfc858
 //* =========================================================================
-using client = telnetpp::options::subnegotiationless_client<
+class client : public telnetpp::options::basic_client<
     telnetpp::options::suppress_ga::detail::option
->;
+>
+{
+};
 
 }}}

--- a/include/telnetpp/options/suppress_ga/server.hpp
+++ b/include/telnetpp/options/suppress_ga/server.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "telnetpp/options/subnegotiationless_server.hpp"
+#include "telnetpp/options/basic_server.hpp"
 #include "telnetpp/options/suppress_ga/detail/protocol.hpp"
 
 namespace telnetpp { namespace options { namespace suppress_ga {
@@ -12,8 +12,10 @@ namespace telnetpp { namespace options { namespace suppress_ga {
 /// Ahead option.
 /// \see https://tools.ietf.org/html/rfc858
 //* =========================================================================
-using server = telnetpp::options::subnegotiationless_server<
+class server : public telnetpp::options::basic_server<
     telnetpp::options::suppress_ga::detail::option
->;
+>
+{
+};
 
 }}}


### PR DESCRIPTION
This reflects the idea that they can be a common base of any option
and not just aliases for particular options.

IMO, it also reads better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/telnetpp/235)
<!-- Reviewable:end -->
