### PR TITLE
Cleanup of several warnings in MSVC

### DIFF
--- a/include/telnetpp/options/mccp/zlib/compressor.hpp
+++ b/include/telnetpp/options/mccp/zlib/compressor.hpp
@@ -52,7 +52,7 @@ public:
       telnetpp::bytes data,
       continuation const &cont) override;
 
-    class impl;
+    struct impl;
     std::unique_ptr<impl> pimpl_;
 };
 

--- a/include/telnetpp/options/mccp/zlib/decompressor.hpp
+++ b/include/telnetpp/options/mccp/zlib/decompressor.hpp
@@ -49,7 +49,7 @@ private:
       telnetpp::bytes data,
       continuation const &cont) override;
 
-    class impl;
+    struct impl;
     std::unique_ptr<impl> pimpl_;
 };
 

--- a/src/options/mccp/zlib/compressor.cpp
+++ b/src/options/mccp/zlib/compressor.cpp
@@ -126,7 +126,7 @@ telnetpp::bytes compressor::transform_chunk(
     }
 
     byte output_buffer[output_buffer_size];
-    pimpl_->stream->avail_in  = data.size();
+    pimpl_->stream->avail_in  = static_cast<uInt>(data.size());
     pimpl_->stream->next_in   = const_cast<telnetpp::byte *>(data.data());
     pimpl_->stream->avail_out = output_buffer_size;
     pimpl_->stream->next_out  = output_buffer;

--- a/src/options/mccp/zlib/decompressor.cpp
+++ b/src/options/mccp/zlib/decompressor.cpp
@@ -102,7 +102,7 @@ telnetpp::bytes decompressor::transform_chunk(
 
     byte receive_buffer[receive_buffer_size];
 
-    pimpl_->stream->avail_in  = data.size();
+    pimpl_->stream->avail_in  = static_cast<uInt>(data.size());
     pimpl_->stream->next_in   = const_cast<telnetpp::byte *>(data.data());
     pimpl_->stream->avail_out = receive_buffer_size;
     pimpl_->stream->next_out  = receive_buffer;

--- a/src/options/new_environ/server.cpp
+++ b/src/options/new_environ/server.cpp
@@ -2,7 +2,7 @@
 #include "telnetpp/options/new_environ/detail/for_each_request.hpp"
 #include "telnetpp/options/new_environ/detail/protocol.hpp"
 #include "telnetpp/options/new_environ/detail/stream.hpp"
-#include <numeric>
+#include <boost/range/algorithm/for_each.hpp>
 #include <utility>
 
 namespace telnetpp { namespace options { namespace new_environ {
@@ -45,28 +45,22 @@ void server::handle_subnegotiation(
     {
         // It can be assumed that this is an empty "SEND" subnegotiation.
         // This is interpreted to have the meaning "Send all the things".
-        std::accumulate(
-            variables_.begin(),
-            variables_.end(),
-            std::ref(response),
-            [&](auto &&storage, auto &&variable) -> telnetpp::byte_storage &
+        boost::for_each(
+            variables_,
+            [&](auto &&variable)
             {
                 this->append_variable(
                     response, variable_type::var, 
                     variable.first, variable.second);
-                return storage;
             });
 
-        std::accumulate(
-            user_variables_.begin(),
-            user_variables_.end(),
-            std::ref(response),
-            [&](auto &&storage, auto &&variable) -> telnetpp::byte_storage &
+        boost::for_each(
+            user_variables_,
+            [&](auto &&variable)
             {
                 this->append_variable(
-                    response, variable_type::uservar, 
+                    response, variable_type::uservar,
                     variable.first, variable.second);
-                return storage;
             });
     }
     else

--- a/test/command_test.cpp
+++ b/test/command_test.cpp
@@ -47,7 +47,7 @@ static command_string const command_strings[] = {
     command_string { telnetpp::command{ 0x1B          }, "command[0x1B]"},
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     commands_can_be_streamed_to_an_ostream,
     commands_with_strings,
     ValuesIn(command_strings)

--- a/test/element_test.cpp
+++ b/test/element_test.cpp
@@ -40,7 +40,7 @@ static element_string const element_strings[] = {
     element_string{ telnetpp::element{telnetpp::subnegotiation{0x01, subnegotiation1_content}}, "element[subnegotiation[0x01, [0x10, 0x80, 0xC0]]]" },
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     elements_can_be_streamed_to_an_ostream,
     elements_with_strings,
     ValuesIn(element_strings)

--- a/test/mccp_zlib_compressor_test.cpp
+++ b/test/mccp_zlib_compressor_test.cpp
@@ -104,7 +104,7 @@ TEST_F(a_started_zlib_compressor, compresses_received_data)
     assert(response == Z_OK);
 
     telnetpp::byte output_buffer[1024];
-    stream.avail_in  = received_data_.size();
+    stream.avail_in  = static_cast<uInt>(received_data_.size());
     stream.next_in   = const_cast<telnetpp::byte *>(received_data_.data());
     stream.avail_out = sizeof(output_buffer);
     stream.next_out  = output_buffer;
@@ -137,7 +137,7 @@ TEST_F(a_started_zlib_compressor, sends_a_stream_end_when_compression_is_ended)
     assert(response == Z_OK);
 
     telnetpp::byte output_buffer[1024];
-    stream.avail_in  = received_data_.size();
+    stream.avail_in  = static_cast<uInt>(received_data_.size());
     stream.next_in   = const_cast<telnetpp::byte *>(received_data_.data());
     stream.avail_out = sizeof(output_buffer);
     stream.next_out  = output_buffer;
@@ -182,7 +182,7 @@ TEST_F(a_started_zlib_compressor, can_compress_large_amounts_of_data)
     telnetpp::byte output_buffer[1024];
     std::vector<telnetpp::byte> decompressed_data;
 
-    stream.avail_in  = received_data_.size();
+    stream.avail_in  = static_cast<uInt>(received_data_.size());
     stream.next_in   = const_cast<telnetpp::byte *>(received_data_.data());
 
     while(stream.avail_in != 0)

--- a/test/mccp_zlib_decompressor_test.cpp
+++ b/test/mccp_zlib_decompressor_test.cpp
@@ -85,7 +85,7 @@ TEST_F(a_started_zlib_decompressor, decompresses_received_data)
     telnetpp::byte output_buffer[1023];
     auto const test_data = "datadatadatadatadatadata"_tb;
 
-    stream.avail_in  = test_data.size();
+    stream.avail_in  = static_cast<uInt>(test_data.size());
     stream.next_in   = const_cast<telnetpp::byte *>(test_data.data());
     stream.avail_out = sizeof(output_buffer);
     stream.next_out  = output_buffer;
@@ -118,7 +118,7 @@ TEST_F(a_started_zlib_decompressor, announces_the_end_of_a_compression_stream)
     telnetpp::byte output_buffer[1023];
     auto const test_data = "datadatadatadatadatadata"_tb;
 
-    stream.avail_in  = test_data.size();
+    stream.avail_in  = static_cast<uInt>(test_data.size());
     stream.next_in   = const_cast<telnetpp::byte *>(test_data.data());
     stream.avail_out = sizeof(output_buffer);
     stream.next_out  = output_buffer;
@@ -151,7 +151,7 @@ TEST_F(a_started_zlib_decompressor, acts_as_if_a_new_stream_after_restarting_dec
     telnetpp::byte output_buffer[1023];
     auto const test_data = "datadatadatadatadatadata"_tb;
 
-    stream.avail_in  = test_data.size();
+    stream.avail_in  = static_cast<uInt>(test_data.size());
     stream.next_in   = const_cast<telnetpp::byte *>(test_data.data());
     stream.avail_out = sizeof(output_buffer);
     stream.next_out  = output_buffer;
@@ -170,7 +170,7 @@ TEST_F(a_started_zlib_decompressor, acts_as_if_a_new_stream_after_restarting_dec
     assert(response == Z_OK);
     zlib_decompressor_.start();
 
-    stream.avail_in  = test_data.size();
+    stream.avail_in  = static_cast<uInt>(test_data.size());
     stream.next_in   = const_cast<telnetpp::byte *>(test_data.data());
     stream.avail_out = sizeof(output_buffer);
     stream.next_out  = output_buffer;
@@ -203,7 +203,7 @@ TEST_F(a_started_zlib_decompressor, acts_as_if_a_new_stream_after_restarting_dec
     telnetpp::byte output_buffer[1023];
     auto const test_data = "datadatadatadatadatadata"_tb;
 
-    stream.avail_in  = test_data.size();
+    stream.avail_in  = static_cast<uInt>(test_data.size());
     stream.next_in   = const_cast<telnetpp::byte *>(test_data.data());
     stream.avail_out = sizeof(output_buffer);
     stream.next_out  = output_buffer;
@@ -224,7 +224,7 @@ TEST_F(a_started_zlib_decompressor, acts_as_if_a_new_stream_after_restarting_dec
     zlib_decompressor_.finish([](auto &&, bool){});
     zlib_decompressor_.start();
 
-    stream.avail_in  = test_data.size();
+    stream.avail_in  = static_cast<uInt>(test_data.size());
     stream.next_in   = const_cast<telnetpp::byte *>(test_data.data());
     stream.avail_out = sizeof(output_buffer);
     stream.next_out  = output_buffer;
@@ -266,7 +266,7 @@ TEST_F(a_started_zlib_decompressor, can_decompress_large_data)
     auto response = deflateInit(&stream, Z_DEFAULT_COMPRESSION);
     assert(response == Z_OK);
 
-    stream.avail_in  = large_data.size();
+    stream.avail_in  = static_cast<uInt>(large_data.size());
     stream.next_in   = const_cast<telnetpp::byte *>(large_data.data());
 
     std::vector<telnetpp::byte> compressed_data;
@@ -318,7 +318,7 @@ TEST_F(a_started_zlib_decompressor, throws_corrupted_stream_error_if_invalid_dat
     telnetpp::byte output_buffer[1023];
     auto const test_data = "datadatadatadatadatadata"_tb;
 
-    stream.avail_in  = test_data.size();
+    stream.avail_in  = static_cast<uInt>(test_data.size());
     stream.next_in   = const_cast<telnetpp::byte *>(test_data.data());
     stream.avail_out = sizeof(output_buffer);
     stream.next_out  = output_buffer;

--- a/test/negotiation_test.cpp
+++ b/test/negotiation_test.cpp
@@ -46,7 +46,7 @@ static negotiation_string const negotiation_strings[] = {
     negotiation_string { telnetpp::negotiation{telnetpp::dont, 0xFF}, "negotiation[DONT, 0xFF]" },
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     negotiations_can_be_streamed_to_an_ostream,
     negotiations_with_strings,
     ValuesIn(negotiation_strings)

--- a/test/parser_test.cpp
+++ b/test/parser_test.cpp
@@ -164,7 +164,7 @@ constexpr telnetpp::byte const ec_bytes[]  = { 0xFF, 0xF7 };
 constexpr telnetpp::byte const el_bytes[]  = { 0xFF, 0xF8 };
 constexpr telnetpp::byte const ga_bytes[]  = { 0xFF, 0xF9 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     commands_are_parsed_to_command_objects,
     for_non_negotiating_commands,
     ValuesIn(
@@ -211,7 +211,7 @@ constexpr telnetpp::byte const iac_sb[]   = { 0xFF, 0xFA };
 constexpr telnetpp::byte const iac_sb_option[] = { 0xFF, 0xFA, 0x00 };
 constexpr telnetpp::byte const iac_sb_option_iac[] = { 0xFF, 0xFA, 0x00, 0xFF };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     negotiations_remain_unparsed,
     for_incomplete_negotiations,
     ValuesIn(
@@ -350,7 +350,7 @@ constexpr telnetpp::byte const wont_negotiation[] = { 0xFF, 0xFC, 0xBC };
 constexpr telnetpp::byte const do_negotiation[]   = { 0xFF, 0xFD, 0xCD };
 constexpr telnetpp::byte const dont_negotiation[] = { 0xFF, 0xFE, 0xDE };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     negotiations_are_parsed_to_negotiation_objects,
     for_complete_negotiations,
     ValuesIn(

--- a/test/subnegotiation_test.cpp
+++ b/test/subnegotiation_test.cpp
@@ -47,7 +47,7 @@ static subnegotiation_string const subnegotiation_strings[] = {
     subnegotiation_string { 0x00, {0xAC, 0xDE}, "subnegotiation[0x00, [0xAC, 0xDE]]" },
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     subnegotiations_can_be_streamed_to_an_ostream,
     subnegotiations_with_strings,
     ValuesIn(subnegotiation_strings)


### PR DESCRIPTION
This includes various type warnings, some nodiscard warnings, and modernizing the deprecated GoogleTest INSTANTIATE_TEST_CASE_P macro.