### PR TITLE
NAWS and MCCP servers now inherit from basic_server

### DIFF
--- a/include/telnetpp/options/mccp/server.hpp
+++ b/include/telnetpp/options/mccp/server.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "telnetpp/server_option.hpp"
+#include "telnetpp/options/mccp/detail/protocol.hpp"
+#include "telnetpp/options/basic_server.hpp"
 
 namespace telnetpp { namespace options { namespace mccp {
 
@@ -10,7 +11,8 @@ class codec;
 /// \brief A server option responsible for negotiating the server part of the
 /// MCCP protocol.
 //* =========================================================================
-class TELNETPP_EXPORT server : public telnetpp::server_option
+class TELNETPP_EXPORT server 
+  : public telnetpp::options::basic_server<detail::option>
 {
 public:
     //* =====================================================================
@@ -36,14 +38,6 @@ public:
     void finish_compression(continuation const &cont);
     
 private:
-    //* =====================================================================
-    /// \brief Called when a subnegotiation is received while the option is
-    /// active.  Override for option-specific functionality.
-    //* =====================================================================
-    void handle_subnegotiation(
-        telnetpp::bytes data,
-        continuation const &cont) override;
-        
     codec &codec_;
     bool   compression_active_;
 };

--- a/include/telnetpp/options/naws/server.hpp
+++ b/include/telnetpp/options/naws/server.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "telnetpp/server_option.hpp"
+#include "telnetpp/options/basic_server.hpp"
+#include "telnetpp/options/naws/detail/protocol.hpp"
 #include <boost/optional.hpp>
 #include <utility>
 
@@ -9,7 +10,8 @@ namespace telnetpp { namespace options { namespace naws {
 //* =========================================================================
 /// \brief An implementation of the server side of the Telnet NAWS option.
 //* =========================================================================
-class TELNETPP_EXPORT server : public telnetpp::server_option 
+class TELNETPP_EXPORT server 
+  : public telnetpp::options::basic_server<detail::option>
 {
 public:
     using window_dimension = std::uint16_t;
@@ -37,14 +39,6 @@ public:
     }
 
 private:
-    //* =====================================================================
-    /// \brief Called when a subnegotiation is received while the option is
-    /// active.  Override for option-specific functionality.
-    //* =====================================================================
-    void handle_subnegotiation(
-        telnetpp::bytes content,
-        continuation const &cont) override;
-
     //* =====================================================================
     /// \brief Report the window size.
     //* =====================================================================

--- a/src/options/mccp/server.cpp
+++ b/src/options/mccp/server.cpp
@@ -1,6 +1,5 @@
 #include "telnetpp/options/mccp/server.hpp"
 #include "telnetpp/options/mccp/codec.hpp"
-#include "telnetpp/options/mccp/detail/protocol.hpp"
 
 namespace telnetpp { namespace options { namespace mccp {
 
@@ -8,8 +7,7 @@ namespace telnetpp { namespace options { namespace mccp {
 // CONSTRUCTOR
 // ==========================================================================
 server::server(codec &cdc)
-  : server_option(detail::option),
-    codec_(cdc),
+  : codec_(cdc),
     compression_active_(false)
 {
     on_state_changed.connect(
@@ -57,15 +55,6 @@ void server::finish_compression(continuation const &cont)
             
         compression_active_ = false;
     }
-}
-
-// ==========================================================================
-// HANDLE_SUBNEGOTIATION
-// ==========================================================================
-void server::handle_subnegotiation(
-    telnetpp::bytes data,
-    continuation const &cont)
-{
 }
 
 }}}

--- a/src/options/naws/server.cpp
+++ b/src/options/naws/server.cpp
@@ -1,5 +1,4 @@
 #include "telnetpp/options/naws/server.hpp"
-#include "telnetpp/options/naws/detail/protocol.hpp"
 
 namespace telnetpp { namespace options { namespace naws {
 
@@ -7,7 +6,6 @@ namespace telnetpp { namespace options { namespace naws {
 // CONSTRUCTOR
 // ==========================================================================
 server::server()
-  : server_option(telnetpp::options::naws::detail::option)
 {
     on_state_changed.connect(
         [this](auto &&cont)
@@ -17,15 +15,6 @@ server::server()
                 this->report_window_size(cont);
             }
         });
-}
-
-// ==========================================================================
-// HANDLE_SUBNEGOTIATION
-// ==========================================================================
-void server::handle_subnegotiation(
-    telnetpp::bytes content,
-    continuation const &cont)
-{
 }
 
 }}}


### PR DESCRIPTION
This means that they do not have to declare the handle_subnegotiation function that they don't use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/telnetpp/237)
<!-- Reviewable:end -->
