### PR TITLE
Telnet++ can now be built as a shared library on MSVC

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,7 +53,7 @@ install:
 build_script:
   - mkdir build
   - cd build
-  - cmake -G "%generator%" -DCMAKE_TOOLCHAIN_FILE=C:/Tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DTELNETPP_WITH_ZLIB=True  ..
+  - cmake -G "%generator%" -DCMAKE_TOOLCHAIN_FILE=C:/Tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DTELNETPP_WITH_ZLIB=True -DBUILD_SHARED_LIBS=%shared% ..
   - cmake --build . --config %configuration%
 
 test_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,11 +14,15 @@ configuration:
   - Debug
   - Release
 
+platform:
+  - x64
+
 environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
   matrix:
-    - platform: x64
+    - shared: True
+    - shared: False
 
 cache:
   - C:\Tools\vcpkg\installed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,8 @@ target_sources(telnetpp
         src/command.cpp
         src/element.cpp
         src/negotiation.cpp
+        src/options/echo/client.cpp
+        src/options/echo/server.cpp
         src/options/mccp/client.cpp
         src/options/mccp/codec.cpp
         src/options/mccp/server.cpp
@@ -206,6 +208,8 @@ target_sources(telnetpp
         src/options/naws/server.cpp
         src/options/new_environ/client.cpp
         src/options/new_environ/server.cpp
+        src/options/suppress_ga/client.cpp
+        src/options/suppress_ga/server.cpp
         src/options/terminal_type/client.cpp
         src/session.cpp
         src/subnegotiation.cpp

--- a/include/telnetpp/option.hpp
+++ b/include/telnetpp/option.hpp
@@ -43,7 +43,7 @@ template <
     telnetpp::command_type LocalNegative,
     telnetpp::command_type RemotePositive,
     telnetpp::command_type RemoteNegative>
-class option
+class TELNETPP_EXPORT option
 {
 public:
     using continuation = std::function<void (telnetpp::element const &)>;

--- a/include/telnetpp/options/basic_client.hpp
+++ b/include/telnetpp/options/basic_client.hpp
@@ -10,7 +10,7 @@ namespace telnetpp { namespace options {
 ///        the option.
 //* =========================================================================
 template <option_type Option>
-class basic_client : public telnetpp::client_option
+class TELNETPP_EXPORT basic_client : public telnetpp::client_option
 {
 public:
     //* =====================================================================

--- a/include/telnetpp/options/basic_server.hpp
+++ b/include/telnetpp/options/basic_server.hpp
@@ -10,7 +10,7 @@ namespace telnetpp { namespace options {
 ///        the option.
 //* =========================================================================
 template <option_type Option>
-class basic_server : public telnetpp::server_option
+class TELNETPP_EXPORT basic_server : public telnetpp::server_option
 {
 public:
     //* =====================================================================

--- a/include/telnetpp/options/echo/client.hpp
+++ b/include/telnetpp/options/echo/client.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "telnetpp/core.hpp"
 #include "telnetpp/options/basic_client.hpp"
 #include "telnetpp/options/echo/detail/protocol.hpp"
 
@@ -11,10 +12,12 @@ namespace telnetpp { namespace options { namespace echo {
 /// \brief An implementation of the client side of Telnet ECHO option
 /// \see https://tools.ietf.org/html/rfc857
 //* =========================================================================
-class client : public telnetpp::options::basic_client<
+class TELNETPP_EXPORT client : public telnetpp::options::basic_client<
     telnetpp::options::echo::detail::option
 >
 {
+public:
+    //client();
 };
 
 }}}

--- a/include/telnetpp/options/echo/server.hpp
+++ b/include/telnetpp/options/echo/server.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "telnetpp/core.hpp"
 #include "telnetpp/options/basic_server.hpp"
 #include "telnetpp/options/echo/detail/protocol.hpp"
 
@@ -11,10 +12,12 @@ namespace telnetpp { namespace options { namespace echo {
 /// \brief An implementation of the server side of Telnet ECHO option
 /// \see https://tools.ietf.org/html/rfc857
 //* =========================================================================
-class server : public telnetpp::options::basic_server<
+class TELNETPP_EXPORT server : public telnetpp::options::basic_server<
     telnetpp::options::echo::detail::option
 >
 {
+public:
+    server() noexcept;
 };
 
 }}}

--- a/include/telnetpp/options/suppress_ga/client.hpp
+++ b/include/telnetpp/options/suppress_ga/client.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "telnetpp/core.hpp"
 #include "telnetpp/options/basic_client.hpp"
 #include "telnetpp/options/suppress_ga/detail/protocol.hpp"
 
@@ -12,10 +13,12 @@ namespace telnetpp { namespace options { namespace suppress_ga {
 /// Ahead option.
 /// \see https://tools.ietf.org/html/rfc858
 //* =========================================================================
-class client : public telnetpp::options::basic_client<
+class TELNETPP_EXPORT client : public telnetpp::options::basic_client<
     telnetpp::options::suppress_ga::detail::option
 >
 {
+public:
+    client() noexcept;
 };
 
 }}}

--- a/include/telnetpp/options/suppress_ga/server.hpp
+++ b/include/telnetpp/options/suppress_ga/server.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "telnetpp/core.hpp"
 #include "telnetpp/options/basic_server.hpp"
 #include "telnetpp/options/suppress_ga/detail/protocol.hpp"
 
@@ -12,10 +13,12 @@ namespace telnetpp { namespace options { namespace suppress_ga {
 /// Ahead option.
 /// \see https://tools.ietf.org/html/rfc858
 //* =========================================================================
-class server : public telnetpp::options::basic_server<
+class TELNETPP_EXPORT server : public telnetpp::options::basic_server<
     telnetpp::options::suppress_ga::detail::option
 >
 {
+public:
+    server() noexcept;
 };
 
 }}}

--- a/src/options/echo/client.cpp
+++ b/src/options/echo/client.cpp
@@ -1,0 +1,7 @@
+#include "telnetpp/options/echo/client.hpp"
+
+namespace telnetpp { namespace options { namespace echo {
+
+//client::client() = default;
+
+}}}

--- a/src/options/echo/server.cpp
+++ b/src/options/echo/server.cpp
@@ -1,0 +1,9 @@
+#include "telnetpp/options/echo/server.hpp"
+
+namespace telnetpp { namespace options { namespace echo {
+
+server::server() noexcept
+{
+}
+
+}}}

--- a/src/options/suppress_ga/client.cpp
+++ b/src/options/suppress_ga/client.cpp
@@ -1,0 +1,9 @@
+#include "telnetpp/options/suppress_ga/client.hpp"
+
+namespace telnetpp { namespace options { namespace suppress_ga {
+
+client::client() noexcept
+{
+}
+
+}}}

--- a/src/options/suppress_ga/server.cpp
+++ b/src/options/suppress_ga/server.cpp
@@ -1,0 +1,9 @@
+#include "telnetpp/options/suppress_ga/server.hpp"
+
+namespace telnetpp { namespace options { namespace suppress_ga {
+
+server::server() noexcept
+{
+}
+
+}}}


### PR DESCRIPTION
Added a couple of missing TELNETPP_EXPORT tags that weren't needed on Linux, and also made it so that echo/suppress_ga clients have an empty constructor that causes the class to be instantiated somewhere in the library.

There's probably a better way to do that.

The upshot is that Telnet++ now builds (noisily, do to a bunch of C4251 warnings) and executes the tests successfully while building as a shared library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/telnetpp/239)
<!-- Reviewable:end -->
