### PR TITLE
MSDP table values are now vectors

### DIFF
--- a/include/telnetpp/options/msdp/variable.hpp
+++ b/include/telnetpp/options/msdp/variable.hpp
@@ -4,7 +4,7 @@
 #include <boost/container/small_vector.hpp>
 #include <boost/variant.hpp>
 #include <iosfwd>
-#include <string>
+#include <vector>
 
 namespace telnetpp { namespace options { namespace msdp {
 
@@ -12,7 +12,7 @@ struct variable;
 
 using string_value = telnetpp::byte_storage;
 using array_value  = boost::container::small_vector<string_value, 4>;
-using table_value  = boost::container::small_vector<variable, 4>;
+using table_value  = std::vector<variable>;
 
 //* =========================================================================
 /// \class telnetpp::options::msdp::value_type


### PR DESCRIPTION
A small vector of a forward-declared type now generates an error with Boost 1.75, so this optimization has been reduced back to a vector while an alternative is sought.

Fixes #238 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/telnetpp/241)
<!-- Reviewable:end -->
