### PR TITLE
More accurate coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,13 +149,13 @@ jobs:
     - name: Install LCOV
       shell: bash
       run: |
-        if [ ! -f "$HOME/.lcov/local/bin/lcov" ]; then
+        if [ ! -f "$HOME/.lcov/usr/local/bin/lcov" ]; then
           mkdir $HOME/.lcov-build || true;
           cd $HOME/.lcov-build;
-          wget https://github.com/linux-test-project/lcov/releases/download/v1.15/lcov-1.15.tar.gz;
-          tar -xzf lcov-1.15.tar.gz;
+          wget https://github.com/linux-test-project/lcov/releases/download/v1.16/lcov-1.16.tar.gz;
+          tar -xzf lcov-1.16.tar.gz;
           mkdir -p $HOME/.lcov || true;
-          DESTDIR=$HOME/.lcov make -C lcov-1.15/ install;
+          DESTDIR=$HOME/.lcov make -C lcov-1.16/ install;
         fi
         echo "##[set-output name=bin;]$(echo $HOME/.lcov/usr/local/bin/lcov)"
       id: lcov

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - build_type: Release
+          - build_type: Debug
 
     env:
       EXTERNAL_ROOT: /home/runner/3party


### PR DESCRIPTION
Coverage build now runs in debug mode.
    
Previously, building on release mode would cause some header files to be optimized out, even with -O0, possibly due to constexpr.

This is great for performance but since these files then generated no coverage data, they were not included in the statistics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/telnetpp/258)
<!-- Reviewable:end -->
