### PR TITLE
Some C++20 improvements

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 image:
-  - Visual Studio 2019
+  - Visual Studio 2022
 
 # Build only on the master branch, and for PRs.
 branches:
@@ -29,7 +29,7 @@ cache:
 
 init:
   - echo Appveyor Image = %APPVEYOR_BUILD_WORKER_IMAGE%
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" ( set "generator=Visual Studio 16 2019" && set "toolset=v142" )
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2022" ( set "generator=Visual Studio 17 2022" && set "toolset=v143" )
   - echo Generator = %generator%
 
 install:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,6 @@
                 "ms-vscode.cpptools-extension-pack",
                 "ms-vscode.cpptools",
                 "ms-vscode.cpptools-themes",
-                "twxs.cmake",
                 "ms-vscode.cmake-tools",
                 "ms-azuretools.vscode-docker",
                 "redhat.vscode-yaml",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -33,9 +33,16 @@
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug"
             }
+        },
+        {
+            "name": "DebugSan",
+            "displayName": "Debug (with sanitizers)",
+            "inherits": "Debug",
+            "cacheVariables": {
+                "TELNETPP_SANITIZE": "address,undefined"
+            }
         }
     ],
-    "buildPresets": [
-    ],
+    "buildPresets": [],
     "testPresets": []
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,17 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive
-RUN apt-get install -y g++ vim cmake git gdb wget libboost1.74-all-dev
+RUN apt-get install -y g++ vim cmake git gdb wget libboost1.83-all-dev
 
-ARG USERNAME=telnetpp
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
+ARG PROJECT=telnetpp
+ARG USERNAME=ubuntu
 
 # Create the user
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME --shell /bin/bash \
-    #
-    # [Optional] Add sudo support. Omit if you don't need to install software after connecting.
-    && apt-get update \
+RUN apt-get update \
     && apt-get install -y sudo \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
 USER $USERNAME
 
-WORKDIR /workspace/$USERNAME
+WORKDIR /workspaces/$PROJECT

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Telnet++ is an implementation of the Telnet Session Layer protocol that is used 
 
 # Requirements
 
-Telnet++ requires a C++17 compiler and the following libraries:
+Telnet++ requires a C++20 compiler and the following libraries:
   * Boost (At least version 1.69.0)
   * (Optionally) ZLib
   * (For testing only) Google Test
@@ -54,7 +54,7 @@ Telnet++ can be installed from source using CMake.  This requires Boost and any 
 
 # Status
 
-Telnet++ is automatically tested with MSVC 2019 and GNU g++ 7.5.
+Telnet++ is automatically tested with MSVC 2022 and GNU g++ 13.3.
 
 # The Basics
 

--- a/include/telnetpp/core.hpp
+++ b/include/telnetpp/core.hpp
@@ -16,22 +16,22 @@ using negotiation_type = std::uint8_t;
 using subnegotiation_content_type = byte;
 
 // TELNET Commands
-static constexpr command_type const se = 240;   // Subnegotiation End
-static constexpr command_type const nop = 241;  // No Operation
-static constexpr command_type const dm = 242;   // Data Mark
-static constexpr command_type const brk = 243;  // Break
-static constexpr command_type const ip = 244;   // Interrupt Process
-static constexpr command_type const ao = 245;   // Abort Output
-static constexpr command_type const ayt = 246;  // Are You There?
-static constexpr command_type const ec = 247;   // Erase Character
-static constexpr command_type const el = 248;   // Erase Line
-static constexpr command_type const ga = 249;   // Go Ahead
-static constexpr command_type const sb = 250;   // Subnegotiation Begin
-static constexpr command_type const will = 251;
-static constexpr command_type const wont = 252;
-static constexpr command_type const do_ = 253;  // NOLINT
-static constexpr command_type const dont = 254;
-static constexpr command_type const iac = 255;  // Interpret As Command
+inline constexpr command_type const se = 240;   // Subnegotiation End
+inline constexpr command_type const nop = 241;  // No Operation
+inline constexpr command_type const dm = 242;   // Data Mark
+inline constexpr command_type const brk = 243;  // Break
+inline constexpr command_type const ip = 244;   // Interrupt Process
+inline constexpr command_type const ao = 245;   // Abort Output
+inline constexpr command_type const ayt = 246;  // Are You There?
+inline constexpr command_type const ec = 247;   // Erase Character
+inline constexpr command_type const el = 248;   // Erase Line
+inline constexpr command_type const ga = 249;   // Go Ahead
+inline constexpr command_type const sb = 250;   // Subnegotiation Begin
+inline constexpr command_type const will = 251;
+inline constexpr command_type const wont = 252;
+inline constexpr command_type const do_ = 253;  // NOLINT
+inline constexpr command_type const dont = 254;
+inline constexpr command_type const iac = 255;  // Interpret As Command
 
 // A stream of bytes in Telnet++ is exposed as a non-owning span.  It is
 // expected that the data will live for no longer than any function in

--- a/include/telnetpp/core.hpp
+++ b/include/telnetpp/core.hpp
@@ -51,7 +51,7 @@ using byte_storage = std::basic_string<byte>;
 // would not find it in our namespace.
 constexpr inline auto bytes_equal = [](bytes const &lhs,
                                        bytes const &rhs) noexcept {
-    return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+    return std::ranges::equal(lhs, rhs);
 };
 
 namespace literals {

--- a/include/telnetpp/detail/command_router.hpp
+++ b/include/telnetpp/detail/command_router.hpp
@@ -7,7 +7,7 @@ namespace telnetpp::detail {
 
 struct command_router_key_from_message_policy
 {
-    static command_type key_from_message(command const &cmd)
+    static constexpr command_type key_from_message(command const &cmd)
     {
         return cmd.value();
     }

--- a/include/telnetpp/detail/negotiation_router.hpp
+++ b/include/telnetpp/detail/negotiation_router.hpp
@@ -8,7 +8,7 @@ namespace telnetpp::detail {
 
 struct negotiation_router_key_from_message_policy
 {
-    static negotiation key_from_message(negotiation const &neg)
+    static constexpr negotiation key_from_message(negotiation const &neg)
     {
         return neg;
     }

--- a/include/telnetpp/detail/return_default.hpp
+++ b/include/telnetpp/detail/return_default.hpp
@@ -5,7 +5,7 @@ namespace telnetpp::detail {
 template <class T>
 struct return_default_constructed
 {
-    T operator()()
+    constexpr T operator()()
     {
         return T{};
     }
@@ -14,7 +14,7 @@ struct return_default_constructed
 template <>
 struct return_default_constructed<void>
 {
-    void operator()()
+    constexpr void operator()()
     {
     }
 };

--- a/include/telnetpp/detail/subnegotiation_router.hpp
+++ b/include/telnetpp/detail/subnegotiation_router.hpp
@@ -8,7 +8,7 @@ namespace telnetpp::detail {
 
 struct subnegotiation_router_key_from_message_policy
 {
-    static option_type key_from_message(subnegotiation const &sub)
+    static constexpr option_type key_from_message(subnegotiation const &sub)
     {
         return sub.option();
     }

--- a/include/telnetpp/element.hpp
+++ b/include/telnetpp/element.hpp
@@ -21,10 +21,9 @@ using element = std::variant<bytes, negotiation, subnegotiation, command>;
 //* =========================================================================
 /// \brief Equality comparison operator for a telnetpp::element.
 //* =========================================================================
-constexpr inline bool operator==(
-    element const &lhs, element const &rhs) noexcept
+constexpr bool operator==(element const &lhs, element const &rhs) noexcept
 {
-    auto visitor = [&rhs](auto const &_lhs) noexcept {
+    auto const visitor = [&rhs](auto const &_lhs) noexcept {
         using T = std::decay_t<decltype(_lhs)>;
         if constexpr (std::is_same_v<T, bytes>)
         {
@@ -36,11 +35,7 @@ constexpr inline bool operator==(
         }
     };
 
-    if (lhs.index() != rhs.index())
-    {
-        return false;
-    }
-    return std::visit(visitor, lhs);
+    return lhs.index() == rhs.index() ? std::visit(visitor, lhs) : false;
 }
 
 //* =========================================================================

--- a/include/telnetpp/option.hpp
+++ b/include/telnetpp/option.hpp
@@ -262,7 +262,7 @@ private:
     //* =====================================================================
     virtual void handle_subnegotiation(telnetpp::bytes data) = 0;
 
-    enum class internal_state
+    enum class internal_state : std::uint8_t
     {
         inactive,
         activating,

--- a/include/telnetpp/options/echo/detail/protocol.hpp
+++ b/include/telnetpp/options/echo/detail/protocol.hpp
@@ -24,6 +24,6 @@
 //* =========================================================================
 namespace telnetpp::options::echo::detail {
 
-static constexpr option_type const option = 1;
+inline constexpr option_type const option = 1;
 
 }  // namespace telnetpp::options::echo::detail

--- a/include/telnetpp/options/mccp/codec.hpp
+++ b/include/telnetpp/options/mccp/codec.hpp
@@ -2,8 +2,9 @@
 
 #include "telnetpp/core.hpp"
 
-#include <boost/exception/all.hpp>
+#include <boost/exception/exception.hpp>
 
+#include <functional>
 #include <stdexcept>
 
 namespace telnetpp::options::mccp {
@@ -49,12 +50,12 @@ private:
     //* =====================================================================
     /// \brief A hook for when the transformation stream starts.
     //* =====================================================================
-    virtual void do_start(){};
+    virtual void do_start() {};
 
     //* =====================================================================
     /// \brief A hook for when transformation stream ends.
     //* =====================================================================
-    virtual void do_finish(continuation const & /*cont*/){};
+    virtual void do_finish(continuation const & /*cont*/) {};
 
     //* =====================================================================
     /// \brief Transform the given bytes, sending the transformed data

--- a/include/telnetpp/options/mccp/detail/protocol.hpp
+++ b/include/telnetpp/options/mccp/detail/protocol.hpp
@@ -65,6 +65,6 @@
 
 namespace telnetpp::options::mccp::detail {
 
-static constexpr option_type const option = 86;
+inline constexpr option_type const option = 86;
 
 }

--- a/include/telnetpp/options/msdp/detail/protocol.hpp
+++ b/include/telnetpp/options/msdp/detail/protocol.hpp
@@ -25,14 +25,14 @@
 //* =========================================================================
 namespace telnetpp::options::msdp::detail {
 
-static constexpr option_type const option = 69;
+inline constexpr option_type const option = 69;
 
 using msdp_command_type = byte;
-static constexpr msdp_command_type const var = 1;
-static constexpr msdp_command_type const val = 2;
-static constexpr msdp_command_type const table_open = 3;
-static constexpr msdp_command_type const table_close = 4;
-static constexpr msdp_command_type const array_open = 5;
-static constexpr msdp_command_type const array_close = 6;
+inline constexpr msdp_command_type const var = 1;
+inline constexpr msdp_command_type const val = 2;
+inline constexpr msdp_command_type const table_open = 3;
+inline constexpr msdp_command_type const table_close = 4;
+inline constexpr msdp_command_type const array_open = 5;
+inline constexpr msdp_command_type const array_close = 6;
 
 }  // namespace telnetpp::options::msdp::detail

--- a/include/telnetpp/options/msdp/variable.hpp
+++ b/include/telnetpp/options/msdp/variable.hpp
@@ -2,8 +2,6 @@
 
 #include "telnetpp/core.hpp"
 
-#include <boost/container/small_vector.hpp>
-
 #include <iosfwd>
 #include <variant>
 #include <vector>
@@ -13,7 +11,7 @@ namespace telnetpp::options::msdp {
 struct variable;
 
 using string_value = telnetpp::byte_storage;
-using array_value = boost::container::small_vector<string_value, 4>;
+using array_value = std::vector<string_value>;
 using table_value = std::vector<variable>;
 
 //* =========================================================================
@@ -33,38 +31,42 @@ struct TELNETPP_EXPORT variable
     //* =====================================================================
     /// \brief Constructor
     //* =====================================================================
-    variable();
+    constexpr variable() = default;
 
     //* =====================================================================
     /// \brief Constructor
     //* =====================================================================
-    variable(telnetpp::byte_storage name, string_value value);
+    constexpr variable(telnetpp::byte_storage name, string_value value)
+      : name_{std::move(name)}, value_{std::move(value)}
+    {
+    }
 
     //* =====================================================================
     /// \brief Constructor
     //* =====================================================================
-    variable(telnetpp::byte_storage name, array_value array_values);
+    constexpr variable(telnetpp::byte_storage name, array_value array_values)
+      : name_{std::move(name)}, value_{std::move(array_values)}
+    {
+    }
 
     //* =====================================================================
     /// \brief Constructor
     //* =====================================================================
-    variable(telnetpp::byte_storage name, table_value table_values);
+    constexpr variable(telnetpp::byte_storage name, table_value table_values)
+      : name_{std::move(name)}, value_{std::move(table_values)}
+    {
+    }
+
+    //* =====================================================================
+    /// \brief Equality operator
+    //* =====================================================================
+    TELNETPP_EXPORT
+    constexpr friend bool operator==(
+        variable const &lhs, variable const &rhs) noexcept = default;
 
     telnetpp::byte_storage name_;
     value_type value_;
 };
-
-//* =========================================================================
-/// \brief Equality operator.
-//* =========================================================================
-TELNETPP_EXPORT
-bool operator==(variable const &lhs, variable const &rhs);
-
-//* =========================================================================
-/// \brief Inequality operator.
-//* =========================================================================
-TELNETPP_EXPORT
-bool operator!=(variable const &lhs, variable const &rhs);
 
 //* =========================================================================
 /// \brief Stream Output operator.

--- a/include/telnetpp/options/naws/client.hpp
+++ b/include/telnetpp/options/naws/client.hpp
@@ -20,7 +20,7 @@ public:
     explicit client(telnetpp::session &sess) noexcept;
 
     boost::signals2::signal<void(window_dimension, window_dimension)>
-        on_window_size_changed;
+        on_window_size_changed;  // NOLINT
 
 private:
     //* =====================================================================

--- a/include/telnetpp/options/naws/detail/protocol.hpp
+++ b/include/telnetpp/options/naws/detail/protocol.hpp
@@ -18,6 +18,6 @@
 //* =========================================================================
 namespace telnetpp::options::naws::detail {
 
-static constexpr option_type const option = 31;
+inline constexpr option_type const option = 31;
 
 }

--- a/include/telnetpp/options/new_environ/detail/for_each_request.hpp
+++ b/include/telnetpp/options/new_environ/detail/for_each_request.hpp
@@ -3,21 +3,18 @@
 #include "telnetpp/core.hpp"
 #include "telnetpp/options/new_environ/detail/request_parser_helper.hpp"
 
+#include <algorithm>
+
 namespace telnetpp::options::new_environ::detail {
 
 template <typename Continuation>
-void for_each_request(telnetpp::bytes requests, Continuation &&cont)
+constexpr void for_each_request(telnetpp::bytes requests, Continuation &&cont)
 {
     request_parsing_state state;
 
-    auto current = requests.begin();
-    auto end = requests.end();
-
-    while (current != end)
-    {
-        parse_request_byte(state, current++, cont);
-    }
-
+    std::ranges::for_each(requests, [&](telnetpp::byte byte) {
+        parse_request_byte(state, byte, cont);
+    });
     parse_request_end(state, cont);
 }
 

--- a/include/telnetpp/options/new_environ/detail/protocol.hpp
+++ b/include/telnetpp/options/new_environ/detail/protocol.hpp
@@ -30,16 +30,16 @@
 //* =========================================================================
 namespace telnetpp::options::new_environ::detail {
 
-static constexpr option_type const option = 39;
+inline constexpr option_type const option = 39;
 
 using new_environ_command_type = byte;
-static constexpr new_environ_command_type const is = 0;
-static constexpr new_environ_command_type const send = 1;
-static constexpr new_environ_command_type const info = 2;
+inline constexpr new_environ_command_type const is = 0;
+inline constexpr new_environ_command_type const send = 1;
+inline constexpr new_environ_command_type const info = 2;
 
-static constexpr new_environ_command_type const var = 0;
-static constexpr new_environ_command_type const value = 1;
-static constexpr new_environ_command_type const esc = 2;
-static constexpr new_environ_command_type const uservar = 3;
+inline constexpr new_environ_command_type const var = 0;
+inline constexpr new_environ_command_type const value = 1;
+inline constexpr new_environ_command_type const esc = 2;
+inline constexpr new_environ_command_type const uservar = 3;
 
 }  // namespace telnetpp::options::new_environ::detail

--- a/include/telnetpp/options/suppress_ga/detail/protocol.hpp
+++ b/include/telnetpp/options/suppress_ga/detail/protocol.hpp
@@ -23,6 +23,6 @@
 //* =========================================================================
 namespace telnetpp::options::suppress_ga::detail {
 
-static constexpr option_type const option = 3;
+inline constexpr option_type const option = 3;
 
 }

--- a/include/telnetpp/options/terminal_type/client.hpp
+++ b/include/telnetpp/options/terminal_type/client.hpp
@@ -23,7 +23,7 @@ public:
     //* =====================================================================
     void request_terminal_type();
 
-    boost::signals2::signal<void(telnetpp::bytes)> on_terminal_type;
+    boost::signals2::signal<void(telnetpp::bytes)> on_terminal_type;  // NOLINT
 
 private:
     //* =====================================================================

--- a/include/telnetpp/options/terminal_type/detail/protocol.hpp
+++ b/include/telnetpp/options/terminal_type/detail/protocol.hpp
@@ -19,10 +19,10 @@
 //* =========================================================================
 namespace telnetpp::options::terminal_type::detail {
 
-static constexpr option_type const option = 24;
+inline constexpr option_type const option = 24;
 
 using terminal_type_command_type = byte;
-static constexpr terminal_type_command_type const is = 0;
-static constexpr terminal_type_command_type const send = 1;
+inline constexpr terminal_type_command_type const is = 0;
+inline constexpr terminal_type_command_type const send = 1;
 
 }  // namespace telnetpp::options::terminal_type::detail

--- a/include/telnetpp/parser.hpp
+++ b/include/telnetpp/parser.hpp
@@ -5,11 +5,7 @@
 #include "telnetpp/negotiation.hpp"
 #include "telnetpp/subnegotiation.hpp"
 
-#include <boost/range/algorithm_ext/insert.hpp>
-#include <boost/range/iterator_range_core.hpp>
-#include <boost/scope_exit.hpp>
-
-#include <vector>
+#include <algorithm>
 
 namespace telnetpp {
 
@@ -17,64 +13,16 @@ class parser final
 {
 public:
     template <typename Continuation>
-    void operator()(telnetpp::bytes data, Continuation &&c)
+    constexpr void operator()(telnetpp::bytes data, Continuation &&c)
     {
-        boost::range::insert(
-            unparsed_data_,
-            unparsed_data_.end(),
-            boost::make_iterator_range(data.begin(), data.end()));
+        std::ranges::for_each(
+            data, [&](telnetpp::byte by) { parse_byte(by, c); });
 
-        if (!std::exchange(currently_parsing_, true))
-        {
-            BOOST_SCOPE_EXIT(&unparsed_data_, &currently_parsing_)
-            {
-                unparsed_data_.clear();
-                currently_parsing_ = false;
-            }
-            BOOST_SCOPE_EXIT_END;
-
-            // Note: this is an indexed loop because it is plausible that
-            // a response to a Telnet message may cause extra data to be
-            // received, which would change the length of the unparsed data.
-            for (unsigned char by : unparsed_data_)
-            {
-                switch (state_)
-                {
-                    case parsing_state::state_idle:
-                        parse_idle(by, c);
-                        break;
-
-                    case parsing_state::state_iac:
-                        parse_iac(by, c);
-                        break;
-
-                    case parsing_state::state_negotiation:
-                        parse_negotiation(by, c);
-                        break;
-
-                    case parsing_state::state_subnegotiation:
-                        parse_subnegotiation(by, c);
-                        break;
-
-                    case parsing_state::state_subnegotiation_content:
-                        parse_subnegotiation_content(by, c);
-                        break;
-
-                    case parsing_state::state_subnegotiation_content_iac:
-                        parse_subnegotiation_content_iac(by, c);
-                        break;
-
-                    default:
-                        break;
-                }
-            }
-
-            emit_plain_data(c);
-        }
+        emit_plain_data(c);
     }
 
 private:
-    enum class parsing_state
+    enum class parsing_state : std::uint8_t
     {
         state_idle,
         state_iac,
@@ -85,8 +33,6 @@ private:
     };
 
     parsing_state state_{parsing_state::state_idle};
-    bool currently_parsing_{false};
-    std::vector<telnetpp::byte> unparsed_data_;
 
     telnetpp::byte_storage plain_data_;
     telnetpp::byte_storage subnegotiation_content_;
@@ -94,7 +40,41 @@ private:
     telnetpp::option_type subnegotiation_option_;
 
     template <typename Continuation>
-    void parse_idle(telnetpp::byte by, Continuation &&c)
+    constexpr void parse_byte(telnetpp::byte by, Continuation &&c)
+    {
+        switch (state_)
+        {
+            case parsing_state::state_idle:
+                parse_idle(by, c);
+                break;
+
+            case parsing_state::state_iac:
+                parse_iac(by, c);
+                break;
+
+            case parsing_state::state_negotiation:
+                parse_negotiation(by, c);
+                break;
+
+            case parsing_state::state_subnegotiation:
+                parse_subnegotiation(by, c);
+                break;
+
+            case parsing_state::state_subnegotiation_content:
+                parse_subnegotiation_content(by, c);
+                break;
+
+            case parsing_state::state_subnegotiation_content_iac:
+                parse_subnegotiation_content_iac(by, c);
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    template <typename Continuation>
+    constexpr void parse_idle(telnetpp::byte by, Continuation &&c)
     {
         switch (by)
         {
@@ -109,7 +89,7 @@ private:
     }
 
     template <typename Continuation>
-    void parse_iac(telnetpp::byte by, Continuation &&c)
+    constexpr void parse_iac(telnetpp::byte by, Continuation &&c)
     {
         switch (by)
         {
@@ -141,14 +121,14 @@ private:
     }
 
     template <typename Continuation>
-    void parse_negotiation(telnetpp::byte by, Continuation &&c)
+    constexpr void parse_negotiation(telnetpp::byte by, Continuation &&c)
     {
         c(telnetpp::negotiation{negotiation_type_, by});
         state_ = parsing_state::state_idle;
     }
 
     template <typename Continuation>
-    void parse_subnegotiation(telnetpp::byte by, Continuation &&c)
+    constexpr void parse_subnegotiation(telnetpp::byte by, Continuation &&c)
     {
         subnegotiation_option_ = by;
         subnegotiation_content_.clear();
@@ -156,7 +136,8 @@ private:
     }
 
     template <typename Continuation>
-    void parse_subnegotiation_content(telnetpp::byte by, Continuation &&c)
+    constexpr void parse_subnegotiation_content(
+        telnetpp::byte by, Continuation &&c)
     {
         switch (by)
         {
@@ -171,7 +152,8 @@ private:
     }
 
     template <typename Continuation>
-    void parse_subnegotiation_content_iac(telnetpp::byte by, Continuation &&c)
+    constexpr void parse_subnegotiation_content_iac(
+        telnetpp::byte by, Continuation &&c)
     {
         switch (by)
         {
@@ -189,7 +171,7 @@ private:
     }
 
     template <typename Continuation>
-    void emit_plain_data(Continuation &&c)
+    constexpr void emit_plain_data(Continuation &&c)
     {
         if (!plain_data_.empty())
         {

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -1,8 +1,6 @@
 #include "telnetpp/command.hpp"
 
-#include <boost/io/ios_state.hpp>
-
-#include <iomanip>
+#include <format>
 #include <iostream>
 
 namespace telnetpp {
@@ -12,47 +10,35 @@ namespace telnetpp {
 // ==========================================================================
 std::ostream &operator<<(std::ostream &out, command const &cmd)
 {
-    out << "command[";
-
-    switch (cmd.value())
-    {
-        case telnetpp::nop:
-            out << "NOP";
-            break;
-        case telnetpp::dm:
-            out << "DM";
-            break;
-        case telnetpp::brk:
-            out << "BRK";
-            break;
-        case telnetpp::ip:
-            out << "IP";
-            break;
-        case telnetpp::ao:
-            out << "AO";
-            break;
-        case telnetpp::ayt:
-            out << "AYT";
-            break;
-        case telnetpp::ec:
-            out << "EC";
-            break;
-        case telnetpp::el:
-            out << "EL";
-            break;
-        case telnetpp::ga:
-            out << "GA";
-            break;
-        default:
+    std::string_view cmd_type = [](command_type const type) {
+        switch (type)
         {
-            boost::io::ios_flags_saver ifs(out);
-            out << "0x" << std::hex << std::setfill('0') << std::setw(2)
-                << std::uppercase << static_cast<int>(cmd.value());
-            break;
+            case telnetpp::nop:
+                return "NOP";
+            case telnetpp::dm:
+                return "DM";
+            case telnetpp::brk:
+                return "BRK";
+            case telnetpp::ip:
+                return "IP";
+            case telnetpp::ao:
+                return "AO";
+            case telnetpp::ayt:
+                return "AYT";
+            case telnetpp::ec:
+                return "EC";
+            case telnetpp::el:
+                return "EL";
+            case telnetpp::ga:
+                return "GA";
+            default:
+                return "";
         }
-    }
+    }(cmd.value());
 
-    return out << "]";
+    return cmd_type != ""
+             ? (out << std::format("command[{}]", cmd_type))
+             : (out << std::format("command[0x{:02X}]", cmd.value()));
 }
 
 }  // namespace telnetpp

--- a/src/negotiation.cpp
+++ b/src/negotiation.cpp
@@ -1,8 +1,6 @@
 #include "telnetpp/negotiation.hpp"
 
-#include <boost/io/ios_state.hpp>
-
-#include <iomanip>
+#include <format>
 #include <iostream>
 
 namespace telnetpp {
@@ -12,30 +10,25 @@ namespace telnetpp {
 // ==========================================================================
 std::ostream &operator<<(std::ostream &out, negotiation const &neg)
 {
-    out << "negotiation[";
+    std::string_view const neg_type = [](negotiation_type const type) {
+        switch (type)
+        {
+            case telnetpp::will:
+                return "WILL";
+            case telnetpp::wont:
+                return "WONT";
+            case telnetpp::do_:
+                return "DO";
+            case telnetpp::dont:
+                return "DONT";
+            default:
+                assert(false);
+                return "";
+        }
+    }(neg.request());
 
-    switch (neg.request())
-    {
-        case telnetpp::will:
-            out << "WILL";
-            break;
-        case telnetpp::wont:
-            out << "WONT";
-            break;
-        case telnetpp::do_:
-            out << "DO";
-            break;
-        case telnetpp::dont:
-            out << "DONT";
-            break;
-        default:
-            assert(false);
-            break;
-    }
-
-    boost::io::ios_flags_saver ifs(out);
-    return out << ", 0x" << std::hex << std::setfill('0') << std::setw(2)
-               << std::uppercase << static_cast<int>(neg.option_code()) << "]";
+    return out << std::format(
+               "negotiation[{}, 0x{:02X}]", neg_type, neg.option_code());
 }
 
 }  // namespace telnetpp

--- a/src/options/mccp/zlib/compressor.cpp
+++ b/src/options/mccp/zlib/compressor.cpp
@@ -1,6 +1,5 @@
 #include "telnetpp/options/mccp/zlib/compressor.hpp"
 
-#include <boost/core/ignore_unused.hpp>
 #include <zlib.h>
 
 #include <optional>
@@ -36,8 +35,8 @@ struct compressor::impl
 
         stream_ = z_stream{};
 
-        auto result = deflateInit(&*stream_, Z_DEFAULT_COMPRESSION);
-        boost::ignore_unused(result);
+        [[maybe_unused]] auto result =
+            deflateInit(&*stream_, Z_DEFAULT_COMPRESSION);
         assert(result == Z_OK);
     }
 
@@ -48,8 +47,7 @@ struct compressor::impl
     {
         assert(stream_ != std::nullopt);
 
-        auto result = deflateEnd(&*stream_);
-        boost::ignore_unused(result);
+        [[maybe_unused]] auto result = deflateEnd(&*stream_);
         assert(result == Z_OK || result == Z_STREAM_ERROR || Z_DATA_ERROR);
 
         stream_ = std::nullopt;
@@ -134,8 +132,7 @@ telnetpp::bytes compressor::transform_chunk(
     pimpl_->stream_->avail_out = output_buffer_size;
     pimpl_->stream_->next_out = output_buffer;
 
-    auto response = deflate(&*pimpl_->stream_, Z_SYNC_FLUSH);
-    boost::ignore_unused(response);
+    [[maybe_unused]] auto response = deflate(&*pimpl_->stream_, Z_SYNC_FLUSH);
     assert(response == Z_OK);
 
     auto const output_data =

--- a/src/options/mccp/zlib/decompressor.cpp
+++ b/src/options/mccp/zlib/decompressor.cpp
@@ -1,6 +1,5 @@
 #include "telnetpp/options/mccp/zlib/decompressor.hpp"
 
-#include <boost/core/ignore_unused.hpp>
 #include <zlib.h>
 
 #include <optional>
@@ -36,8 +35,7 @@ struct decompressor::impl
 
         stream_ = z_stream{};
 
-        auto result = inflateInit(&*stream_);
-        boost::ignore_unused(result);
+        [[maybe_unused]] auto result = inflateInit(&*stream_);
         assert(result == Z_OK);
     }
 
@@ -48,8 +46,7 @@ struct decompressor::impl
     {
         assert(stream_ != std::nullopt);
 
-        auto result = inflateEnd(&*stream_);
-        boost::ignore_unused(result);
+        [[maybe_unused]] auto result = inflateEnd(&*stream_);
         assert(result == Z_OK || result == Z_STREAM_ERROR);
 
         stream_ = std::nullopt;

--- a/src/options/msdp/variable.cpp
+++ b/src/options/msdp/variable.cpp
@@ -7,54 +7,8 @@
 
 #include <ostream>
 #include <sstream>
-#include <tuple>
 
 namespace telnetpp::options::msdp {
-
-// ==========================================================================
-// CONSTRUCTOR
-// ==========================================================================
-variable::variable() = default;
-
-// ==========================================================================
-// CONSTRUCTOR
-// ==========================================================================
-variable::variable(telnetpp::byte_storage name, string_value value)
-  : name_{std::move(name)}, value_{std::move(value)}
-{
-}
-
-// ==========================================================================
-// CONSTRUCTOR
-// ==========================================================================
-variable::variable(telnetpp::byte_storage name, array_value array_values)
-  : name_{std::move(name)}, value_{std::move(array_values)}
-{
-}
-
-// ==========================================================================
-// CONSTRUCTOR
-// ==========================================================================
-variable::variable(telnetpp::byte_storage name, table_value table_values)
-  : name_{std::move(name)}, value_{std::move(table_values)}
-{
-}
-
-// ==========================================================================
-// OPERATOR==
-// ==========================================================================
-bool operator==(variable const &lhs, variable const &rhs)
-{
-    return std::tie(lhs.name_, lhs.value_) == std::tie(rhs.name_, rhs.value_);
-}
-
-// ==========================================================================
-// OPERATOR!=
-// ==========================================================================
-bool operator!=(variable const &lhs, variable const &rhs)
-{
-    return !(lhs == rhs);
-}
 
 // ==========================================================================
 // OPERATOR<<

--- a/src/options/new_environ/client.cpp
+++ b/src/options/new_environ/client.cpp
@@ -5,8 +5,6 @@
 #include "telnetpp/options/new_environ/detail/response_parser_helper.hpp"
 #include "telnetpp/options/new_environ/detail/stream.hpp"
 
-#include <numeric>
-
 namespace telnetpp::options::new_environ {
 
 // ==========================================================================

--- a/src/options/new_environ/server.cpp
+++ b/src/options/new_environ/server.cpp
@@ -4,8 +4,7 @@
 #include "telnetpp/options/new_environ/detail/protocol.hpp"
 #include "telnetpp/options/new_environ/detail/stream.hpp"
 
-#include <boost/range/algorithm/for_each.hpp>
-
+#include <algorithm>
 #include <utility>
 
 namespace telnetpp::options::new_environ {
@@ -29,7 +28,7 @@ byte type_to_byte(variable_type const &type)
 // ==========================================================================
 server::server(telnetpp::session &sess) noexcept
   : telnetpp::server_option(
-      sess, telnetpp::options::new_environ::detail::option)
+        sess, telnetpp::options::new_environ::detail::option)
 {
 }
 
@@ -98,13 +97,13 @@ void server::handle_subnegotiation(telnetpp::bytes data)
     {
         // It can be assumed that this is an empty "SEND" subnegotiation.
         // This is interpreted to have the meaning "Send all the things".
-        boost::for_each(variables_, [&](auto &&variable) {
-            this->append_variable(
+        std::ranges::for_each(variables_, [&](auto &&variable) {
+            append_variable(
                 response, variable_type::var, variable.first, variable.second);
         });
 
-        boost::for_each(user_variables_, [&](auto &&variable) {
-            this->append_variable(
+        std::ranges::for_each(user_variables_, [&](auto &&variable) {
+            append_variable(
                 response,
                 variable_type::uservar,
                 variable.first,
@@ -116,21 +115,19 @@ void server::handle_subnegotiation(telnetpp::bytes data)
         detail::for_each_request(data, [&](request const &req) {
             if (req.type == variable_type::var)
             {
-                auto it = variables_.find(req.name);
-
-                if (it != variables_.end())
+                if (auto const it = variables_.find(req.name);
+                    it != variables_.end())
                 {
-                    this->append_variable(
+                    append_variable(
                         response, variable_type::var, req.name, it->second);
                 }
             }
             else
             {
-                auto it = user_variables_.find(req.name);
-
-                if (it != user_variables_.end())
+                if (auto const it = user_variables_.find(req.name);
+                    it != user_variables_.end())
                 {
-                    this->append_variable(
+                    append_variable(
                         response, variable_type::uservar, req.name, it->second);
                 }
             }

--- a/src/subnegotiation.cpp
+++ b/src/subnegotiation.cpp
@@ -1,10 +1,7 @@
 #include "telnetpp/subnegotiation.hpp"
 
-#include <boost/io/ios_state.hpp>
-
-#include <iomanip>
+#include <format>
 #include <iostream>
-#include <utility>
 
 namespace telnetpp {
 
@@ -13,10 +10,7 @@ namespace telnetpp {
 // ==========================================================================
 std::ostream &operator<<(std::ostream &out, subnegotiation const &sub)
 {
-    boost::io::ios_all_saver ias(out);
-
-    out << "subnegotiation[0x" << std::hex << std::setw(2) << std::setfill('0')
-        << std::uppercase << static_cast<int>(sub.option()) << ", [";
+    out << std::format("subnegotiation[0x{:02X}, [", sub.option());
 
     bool first = true;
 
@@ -27,7 +21,7 @@ std::ostream &operator<<(std::ostream &out, subnegotiation const &sub)
             out << ", ";
         }
 
-        out << "0x" << std::setw(2) << static_cast<int>(by);
+        out << std::format("0x{:02X}", static_cast<int>(by));
     }
 
     return out << "]]";


### PR DESCRIPTION
* Updated Readme and dockerfiles for C++20
* Removed VSCode cmake extension (because its functionality is now baked in elsewhere)
* Added a sanitizer preset
* Replaced file-scope static constexpr variables with inline constexpr
* Used C++20 features where helpers (boost, etc.) were used before.
* Other minor reorganization

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KazDragon/telnetpp/267)
<!-- Reviewable:end -->
